### PR TITLE
add support for url vars inside of anchor part

### DIFF
--- a/web/js/utils.js
+++ b/web/js/utils.js
@@ -9,9 +9,23 @@ function getUrlParam(parameter, defaultvalue) {
 }
 
 function getUrlVars() {
-    var vars = {};
-    var parts = window.location.href.replace(/[?&]+([^=&]+)=([^&]*)/gi, function (m, key, value) {
-        vars[key] = value;
-    });
-    return vars;
+    const parseVars = (str) => {
+        if(str.length <= 1){
+            return {}
+        }
+        const keyValuePairs  = str.substring(1).split("&")
+        const res = {}
+        for (let i = 0; i < keyValuePairs.length; i++) {
+            const keyValuePair = keyValuePairs[i];
+            const [key, value] = keyValuePair.split('=')
+            res[key] = value
+        }
+        return res
+    }
+
+    return Object.assign(
+        {},
+        parseVars(window.location.search),
+        parseVars(window.location.hash)
+    )
 }


### PR DESCRIPTION
The anchor part is only visible to the browser javascript and is not transmitted to the server hosting the page unlike the get variable which is transmitted to the server.

this allows for:
https://IP:3001/#roomname=yourSecretRoom&camon=true