### PR TITLE
Small UI Improvements for usage on smaller screens

### DIFF
--- a/web/css/main.css
+++ b/web/css/main.css
@@ -34,13 +34,13 @@ video {
 
 .userPlaceholder {
   width: 150px;
-  height: 140px;
+  height: 150px;
+  line-height: 150px;
   border-radius: 50%;
   margin-left: auto;
   margin-right: auto;
   background: #8e8effa1;
-  font-size: 8em;
-  padding-top: 10px;
+  font-size: 7em;
   color: #1a1a1a;
   text-align: center;
   position: relative;
@@ -238,6 +238,7 @@ div#centerDiv{
 
 .videoplaceholder {
   position:relative;
+  min-width: 126px;
 }
 
 .videoplaceholder > .userPlaceholderContainer {
@@ -266,6 +267,19 @@ div#centerDiv{
     padding-left: 12px;
     padding-right: 12px;
     width: 45px;
+  }
+
+
+  .videoplaceholder {
+    min-width: 126px;
+  }
+
+  .selfPreview .userPlaceholder {
+    width: 120px;
+    height: 120px;
+    font-size: 5em;
+    line-height: 120px;
+    padding: 0;
   }
 }
 

--- a/web/css/main.css
+++ b/web/css/main.css
@@ -227,7 +227,7 @@ div#centerDiv{
 }
 
 #mediaControll{
-  width: 460px;
+  max-width: 460px;
   margin-left: auto;
   margin-right: auto;
   background: #ffffff3b;

--- a/web/css/main.css
+++ b/web/css/main.css
@@ -213,3 +213,23 @@ div#centerDiv{
   display:none;
   z-index:1;
 }
+
+
+/* UI */
+
+#mediaControllContainer {
+  position: fixed;
+  bottom: 0px;
+  height: 100px;
+  width: 100%;
+  text-align: center;
+  font-size: 2.5em;
+}
+
+#mediaControll{
+  width: 460px;
+  margin-left: auto;
+  margin-right: auto;
+  background: #ffffff3b;
+  border-radius: 5px;
+}

--- a/web/css/main.css
+++ b/web/css/main.css
@@ -236,6 +236,19 @@ div#centerDiv{
   border-radius: 5px;
 }
 
+.videoplaceholder {
+  position:relative;
+}
+
+.videoplaceholder > .userPlaceholderContainer {
+  width:100%;
+  height:100%;
+  position:absolute;
+  overflow:hidden;
+  background: #474747;
+}
+
+
 @media only screen and (max-width: 460px) {
   #mediaControllContainer {
     height: unset;
@@ -249,3 +262,4 @@ div#centerDiv{
     width: 45px;
   }
 }
+

--- a/web/css/main.css
+++ b/web/css/main.css
@@ -248,8 +248,14 @@ div#centerDiv{
   background: #474747;
 }
 
+:root {
+  --selfPreviewBottomOffset: 30px;
+}
 
 @media only screen and (max-width: 460px) {
+  :root {
+    --selfPreviewBottomOffset: 80px;
+  }
   #mediaControllContainer {
     height: unset;
     bottom: 10px;

--- a/web/css/main.css
+++ b/web/css/main.css
@@ -228,8 +228,24 @@ div#centerDiv{
 
 #mediaControll{
   max-width: 460px;
+  width: fit-content;
+  display: flex;
   margin-left: auto;
   margin-right: auto;
   background: #ffffff3b;
   border-radius: 5px;
+}
+
+@media only screen and (max-width: 460px) {
+  #mediaControllContainer {
+    height: unset;
+    bottom: 10px;
+  }
+
+  .callBtn {
+    padding: 8px;
+    padding-left: 12px;
+    padding-right: 12px;
+    width: 45px;
+  }
 }

--- a/web/endcall.html
+++ b/web/endcall.html
@@ -1,6 +1,10 @@
 <html>
     <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, user-scalable=yes, initial-scale=1, maximum-scale=1">
+        <meta name="mobile-web-app-capable" content="yes">
 
+        <title>Video Chat!</title>
     </head>
     <body style="background: black; color: #4bff7a; font-family: monospace;">
         <div style="text-align: center;">Call ended. You may close this tab/window now.</div>

--- a/web/index.html
+++ b/web/index.html
@@ -47,9 +47,6 @@
           <div title="mute / unmute microphon!" id="muteUnmuteMicBtn" class="callBtn"><i class="fas fa-microphone-alt"></i></div>
         </li>
         <li>
-          <div title="cancel call!" id="cancelCallBtn" class="callBtn"><i class="fas fa-phone-slash"></i></div>
-        </li>
-        <li>
           <div title="add / remove camera!" id="addRemoveCameraBtn" class="callBtn"><i class="fas fa-video"></i></div>
         </li>
         <li id="screenBtnContainer">
@@ -57,6 +54,9 @@
         </li>
         <li id="chatBtnContainer">
           <div title="open / close Chat" id="addRemoveChatBtn" class="callBtn"><i class="far fa-comment-dots"></i></div>
+        </li>
+        <li>
+          <div title="cancel call!" id="cancelCallBtn" class="callBtn"><i class="fas fa-phone-slash"></i></div>
         </li>
       </ul>
 

--- a/web/index.html
+++ b/web/index.html
@@ -40,8 +40,8 @@
     <input id="chatInputText" placeholder="your msg..." type="text" width="100%" >
     <div id="chatSendBtn"><i class="fas fa-paper-plane"></i></div>
   </div>
-  <div style="position: fixed; bottom: 0px; height: 100px; width: 100%; text-align: center; font-size: 2.5em;" id="mediaControllContainer">
-    <div style="width: 460px; margin-left: auto; margin-right: auto; background: #ffffff3b; border-radius: 5px;" id="mediaControll">
+  <div id="mediaControllContainer">
+    <div id="mediaControll">
       <ul>
         <li>
           <div title="mute / unmute microphon!" id="muteUnmuteMicBtn" class="callBtn"><i class="fas fa-microphone-alt"></i></div>

--- a/web/index.html
+++ b/web/index.html
@@ -42,24 +42,11 @@
   </div>
   <div id="mediaControllContainer">
     <div id="mediaControll">
-      <ul>
-        <li>
-          <div title="mute / unmute microphon!" id="muteUnmuteMicBtn" class="callBtn"><i class="fas fa-microphone-alt"></i></div>
-        </li>
-        <li>
-          <div title="add / remove camera!" id="addRemoveCameraBtn" class="callBtn"><i class="fas fa-video"></i></div>
-        </li>
-        <li id="screenBtnContainer">
-          <div title="add / remove screen!" id="addRemoveScreenBtn" class="callBtn"><i class="fas fa-desktop"></i></div>
-        </li>
-        <li id="chatBtnContainer">
-          <div title="open / close Chat" id="addRemoveChatBtn" class="callBtn"><i class="far fa-comment-dots"></i></div>
-        </li>
-        <li>
-          <div title="cancel call!" id="cancelCallBtn" class="callBtn"><i class="fas fa-phone-slash"></i></div>
-        </li>
-      </ul>
-
+      <div title="mute / unmute microphon!" id="muteUnmuteMicBtn" class="callBtn"><i class="fas fa-microphone-alt"></i></div>
+      <div title="add / remove camera!" id="addRemoveCameraBtn" class="callBtn"><i class="fas fa-video"></i></div>
+      <div title="add / remove screen!" id="addRemoveScreenBtn" class="callBtn"><i class="fas fa-desktop"></i></div>
+      <div title="open / close Chat" id="addRemoveChatBtn" class="callBtn"><i class="far fa-comment-dots"></i></div>
+      <div title="cancel call!" id="cancelCallBtn" class="callBtn"><i class="fas fa-phone-slash"></i></div>
     </div>
   </div>
   <div id="audioStreams"></div>

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -499,9 +499,12 @@ function updateUserLayout() {
     var userStream = allUserStreams[i];
     streamCnt++;
 
+    // at the moment this is santized by only allowing 2 characters,
+    // but if we should ever change this in the future,
+    // then we should use innerText instead of innerHTML to prevent XSS attacks
     var uDisplay = userStream["username"] && userStream["username"] != "NA" ? userStream["username"].substr(0, 2).toUpperCase() : i.substr(0, 2).toUpperCase();
-    var userDiv = $('<div class="videoplaceholder" style="position:relative;" id="' + i + '">' +
-      '<div class="userPlaceholderContainer" style="width:100%; height:100%; position:absolute; overflow:hidden; background: #474747;">' +
+    var userDiv = $('<div class="videoplaceholder" id="' + i + '">' +
+      '<div class="userPlaceholderContainer">' +
       '<div class="userPlaceholder">' + uDisplay + '</div>' +
       '</div>' +
       '</div>')

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -503,15 +503,15 @@ function updateUserLayout() {
     // but if we should ever change this in the future,
     // then we should use innerText instead of innerHTML to prevent XSS attacks
     var uDisplay = userStream["username"] && userStream["username"] != "NA" ? userStream["username"].substr(0, 2).toUpperCase() : i.substr(0, 2).toUpperCase();
-    var userDiv = $('<div class="videoplaceholder" id="' + i + '">' +
-      '<div class="userPlaceholderContainer">' +
-      '<div class="userPlaceholder">' + uDisplay + '</div>' +
-      '</div>' +
-      '</div>')
+    var userDiv = $(`<div class="videoplaceholder" id="${i}">
+      <div class="userPlaceholderContainer">
+        <div class="userPlaceholder">${uDisplay}</div>
+      </div>
+    </div>`)
 
     if (userStream["audiostream"] && i !== MY_UUID) {
       if ($("#audioStreams").find('#audio' + i).length == 0) {
-        let audioDiv = $('<div id="audio' + i + '" style="display:none;"><audio autoplay></audio></div>');
+        let audioDiv = $(`<div id="audio${i}" style="display:none;"><audio autoplay></audio></div>`);
         audioDiv.find("audio")[0].srcObject = userStream["audiostream"];
         $("#audioStreams").append(audioDiv);
       }

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -569,7 +569,7 @@ function updateUserLayout() {
   if (streamCnt == 2) { //Display 2 users side by side
     for (var i in allUserDivs) {
       if (i == MY_UUID) {
-        allUserDivs[i].css({ width: '20%', height: '30%', position: 'absolute', left: '20px', bottom: '30px', 'z-index': '1' });
+        allUserDivs[i].css({ width: '20%', height: '30%', position: 'absolute', left: '20px', bottom: 'var(--selfPreviewBottomOffset)', 'z-index': '1' });
       } else {
         allUserDivs[i].css({ width: '100%', height: '100%', float: 'left' });
       }

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -569,7 +569,8 @@ function updateUserLayout() {
   if (streamCnt == 2) { //Display 2 users side by side
     for (var i in allUserDivs) {
       if (i == MY_UUID) {
-        allUserDivs[i].css({ width: '20%', height: '30%', position: 'absolute', left: '20px', bottom: 'var(--selfPreviewBottomOffset)', 'z-index': '1' });
+        allUserDivs[i].addClass("selfPreview")
+        .css({ width: '20%', height: '30%', position: 'absolute', left: '20px', bottom: 'var(--selfPreviewBottomOffset)', 'z-index': '1' });
       } else {
         allUserDivs[i].css({ width: '100%', height: '100%', float: 'left' });
       }

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -24,8 +24,7 @@ if (base64Domain && socketDomain) {
 
 var isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
 if (isMobile) { //No Screenshare on mobile devices
-  $("#screenBtnContainer").hide();
-  $("#mediaControll").css({ width: "270px" })
+  $("#addRemoveScreenBtn").hide();
 }
 
 const SocketIO_Options = { withCredentials: false }


### PR DESCRIPTION
- **move inline styles to css file**
- **change order of buttons, hang up button last, so it is displayed on the bottom on mobile**
- **max width instead of just width for mediaControl - looks better on mobile**
- **improve menu bar styles on mobile**
- **move videoplaceholder inline styles to class**
- **string concatenation to template string for videoplaceholder and audio element**
- **lift self preview up on mobile devices with small screen**
- **- bigger self preview on mobile, - smaller self preview avatar - and improve text centering of the placeholder avatar**


closes #22

|before|after|
|----------|-------|
|<img width="750" height="1334" alt="Screen Shot 2025-09-18 at 19 45 57" src="https://github.com/user-attachments/assets/bef771fa-3a6c-4954-a93d-bf34fdfdbc67" />|<img width="750" height="1334" alt="Screen Shot 2025-09-18 at 19 41 59" src="https://github.com/user-attachments/assets/23859195-04ae-4173-9007-79be7da2dc67" />|
